### PR TITLE
Fixed all headers without spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ http://www.cs.tufts.edu/~couch/
 With help from:  
 Junho Ahn - 2012
 
-##Assignment Introduction
+## Assignment Introduction
 
 All modern operating systems use virtual memory and paging in order to effectively utilize the computer’s memory hierarchy. Paging is an effective means of providing memory space protection to processes, of enabling the system to utilize secondary storage for additional memory space, and of avoiding the need to allocate memory sequentially for each process.
 
@@ -27,11 +27,11 @@ We have studied how virtual memory systems are structured and how the MMU conver
 
 As you might imagine, how the OS chooses which page to evict when it has reached the limit of available physical pages (sometime called frames) can have a major effect on the performance of the memory access on a given system. In this assignment, we will look at various strategies for managing the system page table and controlling when pages are paged in and when they are paged out.
 
-##Your Task
+## Your Task
 
 The goal of this assignment is to implement a paging strategy that maximizes the performance of the memory access in a set of predefined programs. You will accomplish this task by using a paging simulator that has already been created for you. Your job is to write the paging strategy that the simulator utilizes (roughly equivalent to the role the page fault handler plays in a real OS). Your initial goal will be to create a Least Recently Used paging implementation. You will then need to implement some form of predictive page algorithm to increase the performance of your solution. You will be graded on the throughput of your solution (the ratio of time spent doing useful work vs time spent waiting on the necessary paging to occur).
 
-###2.1 The Simulator Environment
+### 2.1 The Simulator Environment
 The simulator has been provided for you. You have access to the source code if you wish to review it (simulator.c and simulator.h), but you should not need to modify this code for the sake of this assignment. You will be graded using the stock simulator, so any enhancements to the simulator program made with the intention of improving your performance will be for naught.
 
 The simulator runs a random set of programs utilizing a limited number of shared physical pages. Each process has a fixed number of virtual pages, the process’s virtual memory space, that it might try to access. For the purpose of this simulation, all memory access is due to the need to load program code. Thus, the simulated program counter (PC) for each process dictates which memory location that process currently requires access to, and thus which virtual page must be swapped-in for the process to successfully continue.
@@ -39,7 +39,7 @@ The simulator runs a random set of programs utilizing a limited number of shared
 The values of the constants mentioned above are available in the simulator.h file. For the purposes of grading your assignment, the default values will be used:
 * 20 virtual pages per process (MAXPROCPAGES)
 * 100 physical pages (frames) total (PHYSICALPAGES)
-* 20 simultaneous processes competing for pages (MAXPROCESSES) 
+* 20 simultaneous processes competing for pages (MAXPROCESSES)
 * 128 memory unit page size (PAGESIZE)
 * 100 tick delay to swap a page in or out (PAGEWAIT)
 
@@ -47,7 +47,7 @@ As you can see, you are working in a very resource constrained environment. You 
 
 In addition, swapping a page in or out is an expensive operation, requiring 100 ticks to complete. A tick is the minimum time measurement unit in the simulator. Each instruction or step in the simulated programs requires 1 tick to complete. Thus, in the worst case where every instruction is a page miss (requiring a swap-in), you will spend 100 ticks of paging overhead for every 1 tick of useful work. If all physical pages are in use, this turns into 200 ticks per page miss since you must also spend 100 ticks swapping a page out in order to make room for the required page to be swapped in. This leads to an “overhead to useful work” ratio of 200 to 1: very, very, poor performance. Your goal is to implement a system that does much better than this worst case scenario.
 
-###2.2 The Simulator Interface
+### 2.2 The Simulator Interface
 
 The simulator exports three functions through which you will interact with it. The first function is called pageit. This is the core paging function. It is roughly equivalent to the page-fault handler in your operating system. The simulator calls pageit anytime something interesting happens (memory access, page fault, process completion, etc). It passes the function a page map for each process, as well as the current value of the program counter for each process. See simulator.h for details. You will implement your paging strategy in the body of this function.
 
@@ -72,13 +72,13 @@ The simulator also exports a function called pagein and a function called pageou
 
 Figure 1 shows the possible states that a virtual page can occupy, as well as the possible transitions between these states. Note that the page map values alone do not define all possible page states. We must also account for the possible operations currently underway on a page to fully define its state. While the page map for each process can be obtained from the pageit input array of structs, there is no interface to directly reveal any operations underway on a given page. If knowing whether or not a paging operation is underway on a given page (and thus knowing the full state of a page) is necessary for your pageit implementation, you must maintain this data yourself.
 
-###2.3 The Simulated Programs
+### 2.3 The Simulated Programs
 
 The simulator populates its 20 processes by randomly selecting processes from a collection of 5 simulated “programs”. Pseudo code for each of the possible 5 programs is provided in Listings 1 through 5.
 
 ```
 # loop with inner branch
-	for 10 30 
+	for 10 30
 		run 500
 		if.4
 			run 900
@@ -89,7 +89,7 @@ The simulator populates its 20 processes by randomly selecting processes from a 
 	exit
 endprog
 ```
-####Listing 1: Test Program 1 - A loop with an inner branch
+#### Listing 1: Test Program 1 - A loop with an inner branch
 
 ```
 # one loop
@@ -99,7 +99,7 @@ endprog
 	exit
 endprog
 ```
-####Listing 2: Test Program 2 - Single loop
+#### Listing 2: Test Program 2 - Single loop
 
 ```
 # double-nested loop
@@ -175,12 +175,12 @@ There are a number of additional predictive notions that might prove useful invo
 
 We provide some code to help get you started. Feel free to use it as a jumping off point (appropriately cited).
 
-###Folders
+### Folders
 
 -  handout - Assignment description and documentation
 -  writeup - Images for write up README.md file
 
-###Files
+### Files
 
 -  Makefile - GNU makefile to build all relevant code
 -  pager-basic.c - Basic paging strategy implementation that runs one process at a time.  
@@ -192,7 +192,7 @@ We provide some code to help get you started. Feel free to use it as a jumping o
 -  programs.c - Defines test "programs" for simulator to run
 -  pgm*.pseudo - Pseudo code of test programs from which programs.c was generated.
 
-###Executables
+### Executables
 -  test-* - Runs simulator using "programs" defined in programs.c and paging strategy defined in pager-*.c. Includes various run-time options. Run with '-help' for details.
 -  test-api - Runs a test of the simulator state changes
 -  see.R - An R script for displaying a visualization of the process run/block activity in a simulation. You must first run ./test-* -csv to generate the necessary trace files.


### PR DESCRIPTION
Lack of spacing in headers (i.e. ###hello) stops header from rendering properly.  